### PR TITLE
Move script tags to end of body

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,62 +1,60 @@
 <!DOCTYPE html>
 <html>
+    <head>
+        <title>
+            Giffinder
+        </title>
 
-  <head>
-      <title>
-        Giffinder
-      </title>
-      
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
-      <script src="js/script.js" async></script>
-      <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-      <!-- Latest compiled and minified CSS -->
-      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
-      <link type="text/css" rel="stylesheet" href="css/style.css" />
-  </head>
-  <body>
+        <!-- Latest compiled and minified CSS -->
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+        <link type="text/css" rel="stylesheet" href="css/style.css" />
+    </head>
+    <body>
 
-      <!-- Navigation -->
-      <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-          <div class="container">
-              <div class="navbar-header">
-                  <a class="navbar-brand" href="#">Giffinder</a>
-              </div>
-              <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-                  <div class="col-sm-3 col-md-3 pull-right">
-                      <div class="navbar-form" role="search">
-                        <div class="input-group">
-                          <input type="text" class="form-control" placeholder="Search" name="srch-term" id="srch-term">
-                          <div class="input-group-btn">
-                              <button class="btn btn-default" type="submit"><span class="glyphicon glyphicon-search"></span></button>
-                          </div>
+        <!-- Navigation -->
+        <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+            <div class="container">
+                <div class="navbar-header">
+                    <a class="navbar-brand" href="#">Giffinder</a>
+                </div>
+                <div class="collapse navbar-collapse">
+                    <div class="col-sm-3 col-md-3 pull-right">
+                        <div class="navbar-form" role="search">
+                            <div class="input-group">
+                                <input type="text" class="form-control" placeholder="Search" name="search-term" id="search-term">
+                                <div class="input-group-btn">
+                                    <button class="btn btn-default" type="submit" id="search-button"><span class="glyphicon glyphicon-search"></span></button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
-              </div>
-              <!-- /.navbar-collapse -->
-          </div>
-          <!-- /.container -->
-      </nav>
-
-      <!-- Page Content -->
-      <section>
-        <div class="container"> 
-            <div class="row gallery">
-                  <h3 class="text-center">  Search for a Gif above <br> Your results will display here</h3>
+                <!-- /.navbar-collapse -->
             </div>
-        </div> 
-      <section>
-      <!-- Footer -->
-      <footer>
-          <div class="container">
-              <div class="row">
-                  <div class="col-lg-12">
-                      <p>Copyright &copy; Your Website 2017</p>
-                  </div>
-              </div>
-          </div>
-      </footer>   
+            <!-- /.container -->
+        </nav>
 
-  </body>
+        <!-- Page Content -->
+        <div class="container">
+            <div class="row gallery">
+                <h3 class="text-center">  Search for a Gif above <br> Your results will display here</h3>
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <footer>
+            <div class="container">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <p>Copyright &copy; Your Website 2017</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
+
+        <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+        <script src="js/script.js" async></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    </body>
 
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -2,9 +2,7 @@
 //******************TEST EARLY AND OFTEN USING console.log() ******************
 //****************** SERIOUSLY TEST USING console.log()!!! ******************
 
-$(document).ready(function(){
-  
-  
-  
-  
+$("#search-button").on("click", function() {
+
 });
+


### PR DESCRIPTION
Moving the script tags to the end of body allows us to remove the `document.ready` function from the starter `js/script.js`. 

I also did the following:
1) Updated jquery from 2.1.1 to 3.1.1 so students don't have to do anything special to see the most up-to-date docs at http://api.jquery.com/
2) Removed some extra unclosed `<section>` tags.
3) Added a starter click handler so that the starter code won't be completely empty. 

The changes are easier to see with the link https://github.com/ScriptEdcurriculum/giffinder/pull/2/files?w=1 (which ignores whitespace changes). 